### PR TITLE
Updates to README.md for logo accessibility and url for importing application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-![test](/images/Itsaplant.png)
+![Graphic of the words "It's a plant!" to the left of an image of a potted plant.](/images/Itsaplant.png)
 
 # Plants
 
 Let's create a new plant app! Should we track the plants we have? Track when they were watered, how healthy they are, what kind of fertilizer they like? Where do they live?
 
 🔔🔔🔔<br>
-***CONTRIBUTORS must follow all guidelines in [CONTRIBUTING.md](CONTRIBUTING.md)*** or run the risk of having your Pull Requests labeled as spam.<br>
+**_CONTRIBUTORS must follow all guidelines in [CONTRIBUTING.md](CONTRIBUTING.md)_** or run the risk of having your Pull Requests labeled as spam.<br>
 🔔🔔🔔
 
 ## Getting started
@@ -14,13 +14,14 @@ Let's create a new plant app! Should we track the plants we have? Track when the
 2. Go to your ServiceNow instance
 3. Go to `System Applications` => `Studio`
 4. Once Studio loads, select `Import From Source Control`
-5. Use your forked repo to [Import your application](https://developer.servicenow.com/dev.do#!/learn/learning-plans/quebec/new_to_servicenow/app_store_learnv2_devenvironment_quebec_importing_an_application_from_source_control)
+5. Use your forked repo to [Import your application](https://developer.servicenow.com/dev.do#!/learn/learning-plans/vancouver/new_to_servicenow/app_store_learnv2_devenvironment_vancouver_importing_an_application_from_source_control)
 6. Make updates to the application
 7. In Studio, commit your changes to source control
 8. Submit a pull request to the ServiceNowDevProgram/Plants
- `main` branch
+   `main` branch
 
 ## Contribution ideas
+
 - Automate task creation for watering, fertilizing, etc
 - Create an experience to be able to manage your plants
 - Bring in plant data from other sources


### PR DESCRIPTION
I noticed the logo's alt tag had _test_ in it. I added an alt description that describes what the logo is; this will also help individuals with screen readers to understand the logo's design.

Additionally, I updated the URL for Importing an Application from Source Control to reference the Vancouver release instead of the Quebec release.