### PR TITLE
398 documentation update for import from application

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ See the Issues tab for ideas on what to work on. Make sure to leave a comment on
 2. Go to your ServiceNow instance
 3. Go to `System Applications` => `Studio`
 4. Once Studio loads, select `Import From Source Control`
-5. Use your forked repo to [Import your application](https://developer.servicenow.com/dev.do#!/learn/learning-plans/quebec/new_to_servicenow/app_store_learnv2_devenvironment_quebec_importing_an_application_from_source_control)
+5. Use your forked repo to [Import your application](https://developer.servicenow.com/dev.do#!/learn/learning-plans/latest/new_to_servicenow/app_store_learnv2_devenvironment_latest_importing_an_application_from_source_control)
 6. Make updates to the application
 7. In Studio, commit your changes to source control
 8. Submit a pull request to the ServiceNowNextExperience/Plants `main` branch

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Let's create a new plant app! Should we track the plants we have? Track when the
 2. Go to your ServiceNow instance
 3. Go to `System Applications` => `Studio`
 4. Once Studio loads, select `Import From Source Control`
-5. Use your forked repo to [Import your application](https://developer.servicenow.com/dev.do#!/learn/learning-plans/vancouver/new_to_servicenow/app_store_learnv2_devenvironment_vancouver_importing_an_application_from_source_control)
+5. Use your forked repo to [Import your application](https://developer.servicenow.com/dev.do#!/learn/learning-plans/latest/new_to_servicenow/app_store_learnv2_devenvironment_latest_importing_an_application_from_source_control)
 6. Make updates to the application
 7. In Studio, commit your changes to source control
 8. Submit a pull request to the ServiceNowDevProgram/Plants


### PR DESCRIPTION
Closes #398 

Changed README.md and CONTRIBUTING.md's _import from application_ hyperlink to use the **latest** term instead of the family release name, which will make these links evergreen.