### PR TITLE
Add GitHub action to delete checksum files whenever they're modified

### DIFF
--- a/.github/workflows/checksum.yaml
+++ b/.github/workflows/checksum.yaml
@@ -1,0 +1,39 @@
+name: Delete Checksum Files
+on:
+  push:
+    paths:
+      - '**/checksum.txt'
+  workflow_dispatch:
+
+jobs:
+  delete_files:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+
+    - name: Delete checksum files
+      run: |
+        npm install @actions/glob @actions/io
+        node -e "
+          const glob = require('@actions/glob');
+          const io = require('@actions/io');
+          const { execSync } = require('child_process');
+          (async () => {
+            const pattern = '**/checksum.txt';
+            const globber = await glob.create(pattern);
+            for await (const file of globber.globGenerator()) {
+              await io.rmRF(file);
+              console.log('Deleted: ' + file);
+            }
+            execSync('git config --global user.name \"github-actions[bot]\"');
+            execSync('git config --global user.email \"github-actions[bot]@users.noreply.github.com\"');
+            execSync('git add \"*checksum.txt\"');
+            execSync('git commit -m \"Delete checksum files\"');
+            execSync('git push');
+          })();
+        "


### PR DESCRIPTION
This action runs whenever `*checksum.txt` is modified and pushed. It will delete the file, then add a commit for the deletion to the current branch.

Example run (note this will be cleaned up eventually):
https://github.com/chelming/Plants/actions/runs/11645400073

Commit history:
https://github.com/chelming/Plants/commits/test-modify-checksum?since=2024-11-02&until=2024-11-02

Example deletion commit:
https://github.com/chelming/Plants/commit/ae0f15716060ebe8d21b5299097dff6e5b7eee16